### PR TITLE
Compatibility with vue-cli-plugin-nativescript-vue

### DIFF
--- a/removeUnsupported.js
+++ b/removeUnsupported.js
@@ -15,6 +15,14 @@ module.exports = postcss.plugin('postcss-nativescript', () => {
   return root => {
     root.walkRules(rule => {
       rule.walkDecls(decl => {
+        /**
+         * Allows usage of em/rem values for web
+         * by specifying a multiplier (ex: 16).
+         */
+        if (decl.value.includes('rem')) {
+          decl.value = parseInt(decl.value) * 16
+        }
+        
         if(decl.prop === 'visibility') {
           switch (decl.value) {
             case 'hidden':
@@ -30,8 +38,12 @@ module.exports = postcss.plugin('postcss-nativescript', () => {
               return
           }
         }
-
-        if(!isSupportedProperty(decl.prop, decl.value)) {
+        
+        /**
+         * Remove the "currentColor" value that is not supported
+         * in Nativescript.
+         */
+        if(decl.value === 'currentColor' || !isSupportedProperty(decl.prop, decl.value)) {
           // console.log('removing ', decl.prop, decl.value)
           rule.removeChild(decl)
 


### PR DESCRIPTION
I've used your plugin in combination with the vue-cli-plugin-nativescript-vue and needed to tweak it a little to make it work, while keeping the exact same configuration on both web and native. 
i don't know if that's very useful, just wanted to share in case someone else is doing the same :)